### PR TITLE
Fix intake parsing and keep chat history in sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ lerna-debug.log*
 out/
 build/
 dist/
+.test-dist/
+apps/web/.test-dist/
 
 # Environment variables
 .env

--- a/apps/web/app/api/agent/route.ts
+++ b/apps/web/app/api/agent/route.ts
@@ -3,6 +3,7 @@ import { getOrCreateSession, appendMessage, updateSession } from '@/lib/state';
 import { computeInitialRate } from '@/lib/rate';
 import { counterOffer, isAtFloor } from '@/lib/negotiation';
 import { STR } from '@/lib/prompts';
+import { parseFirstTimeBuyer } from '@/lib/intake';
 
 export async function POST(request: NextRequest) {
   try {
@@ -48,16 +49,11 @@ export async function POST(request: NextRequest) {
         intake.assets = 0;
         fieldsUpdated = true;
       }
-      
+
       // Extract first-time buyer - more flexible patterns
-      if (lowerMessage.includes('first') && (lowerMessage.includes('yes') || lowerMessage.includes('true') || lowerMessage.includes('am'))) {
-        intake.firstTimeBuyer = true;
-        fieldsUpdated = true;
-      } else if (lowerMessage.includes('first') && (lowerMessage.includes('no') || lowerMessage.includes('false') || lowerMessage.includes('not'))) {
-        intake.firstTimeBuyer = false;
-        fieldsUpdated = true;
-      } else if (lowerMessage.includes('not') && lowerMessage.includes('first')) {
-        intake.firstTimeBuyer = false;
+      const firstTimeBuyer = parseFirstTimeBuyer(message);
+      if (firstTimeBuyer !== undefined) {
+        intake.firstTimeBuyer = firstTimeBuyer;
         fieldsUpdated = true;
       }
       

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -69,7 +69,9 @@ export default function Home() {
 
       const data = await response.json();
       
-      if (data.reply) {
+      if (data.state && Array.isArray(data.state.history) && data.state.history.length > 0) {
+        setMessages(data.state.history);
+      } else if (data.reply) {
         const agentMessage: ChatMessage = {
           id: uuidv4(),
           role: 'agent',
@@ -77,14 +79,6 @@ export default function Home() {
           timestamp: Date.now(),
         };
         setMessages(prev => [...prev, agentMessage]);
-      }
-
-      // Check if there are additional messages in the state (like notary completion)
-      if (data.state && data.state.history) {
-        const newMessages = data.state.history.slice(messages.length + 1); // Skip already displayed messages
-        if (newMessages.length > 0) {
-          setMessages(prev => [...prev, ...newMessages]);
-        }
       }
 
     } catch (error) {

--- a/apps/web/lib/__tests__/intake.test.ts
+++ b/apps/web/lib/__tests__/intake.test.ts
@@ -1,0 +1,30 @@
+import { parseFirstTimeBuyer } from '../intake';
+
+function assertEqual(actual: unknown, expected: unknown, description: string) {
+  if (actual !== expected) {
+    throw new Error(`${description} - expected ${expected}, received ${actual}`);
+  }
+}
+
+function assertUndefined(value: unknown, description: string) {
+  if (value !== undefined) {
+    throw new Error(`${description} - expected undefined, received ${value}`);
+  }
+}
+
+(function runTests() {
+  assertEqual(parseFirstTimeBuyer('I am a first time buyer.'), true, 'Affirmative statement should return true');
+  assertEqual(parseFirstTimeBuyer('Yes, first-time buyer here!'), true, 'Affirmation with punctuation should return true');
+  assertEqual(parseFirstTimeBuyer("It's my first time buying a home."), true, 'Indirect confirmation should return true');
+
+  assertEqual(parseFirstTimeBuyer('I am not a first time buyer.'), false, 'Negated statement should return false');
+  assertEqual(parseFirstTimeBuyer('No, not a first-time buyer.'), false, 'Explicit negative response should return false');
+
+  assertUndefined(
+    parseFirstTimeBuyer('What qualifies someone as a first time buyer?'),
+    'Clarifying question should not set status',
+  );
+  assertUndefined(parseFirstTimeBuyer('Tell me about mortgage options.'), 'Unrelated message should not set status');
+
+  console.log('parseFirstTimeBuyer tests passed');
+})();

--- a/apps/web/lib/intake.ts
+++ b/apps/web/lib/intake.ts
@@ -1,0 +1,89 @@
+const FIRST_TIME_REGEX = /\b(?:first|1st)(?:\s|-)*time(?:\s+(?:home\s*)?buyer|\s+homeowner)?\b/;
+const NEGATION_TOKENS = [
+  'not',
+  "don't",
+  'dont',
+  "didn't",
+  'didnt',
+  'no',
+  'never',
+  "isn't",
+  'isnt',
+  "aren't",
+  'arent',
+  "ain't",
+  'aint',
+  'without',
+];
+const AFFIRMATIVE_TOKENS = [
+  'yes',
+  'yeah',
+  'yep',
+  'yup',
+  'sure',
+  'correct',
+  'true',
+  'absolutely',
+  'indeed',
+  'definitely',
+  'affirmative',
+];
+
+const NEGATION_REGEX = new RegExp(`\\b(?:${NEGATION_TOKENS.join('|')})\\b`);
+const AFFIRMATIVE_REGEX = new RegExp(`\\b(?:${AFFIRMATIVE_TOKENS.join('|')})\\b`);
+const PRONOUN_REGEX = /\b(?:i\s*(?:am|'m)|we\s*(?:are|'re)|this\s+is\s+my|it's\s+my|its\s+my)\b/;
+const DECLARATIVE_REGEX = /\bfirst(?:\s|-)*time\s+buyer(?:\s+here)?\b/;
+
+export function parseFirstTimeBuyer(message: string): boolean | undefined {
+  if (!message) {
+    return undefined;
+  }
+
+  const lower = message.toLowerCase();
+
+  if (!FIRST_TIME_REGEX.test(lower)) {
+    return undefined;
+  }
+
+  const segments = (lower.match(/[^.!?]+[.!?]?/g) || [])
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  const relevantSegments = segments.length > 0
+    ? segments.filter((segment) => FIRST_TIME_REGEX.test(segment))
+    : [lower];
+
+  if (relevantSegments.length === 0) {
+    return undefined;
+  }
+
+  const hasNegation = relevantSegments.some((segment) => {
+    if (!NEGATION_REGEX.test(segment)) {
+      return /\b(?:not|no)\b[^.]*\b(?:first|1st)\b/.test(segment) ||
+             /\b(?:first|1st)\b[^.]*\b(?:not|no)\b/.test(segment);
+    }
+    return true;
+  });
+
+  if (hasNegation) {
+    return false;
+  }
+
+  const hasAffirmation = relevantSegments.some((segment) => {
+    const isQuestion = segment.endsWith('?');
+
+    if (AFFIRMATIVE_REGEX.test(segment) || PRONOUN_REGEX.test(segment)) {
+      return true;
+    }
+
+    return !isQuestion && DECLARATIVE_REGEX.test(segment);
+  });
+
+  if (hasAffirmation) {
+    return true;
+  }
+
+  const endsWithQuestion = relevantSegments.every((segment) => segment.endsWith('?'));
+
+  return endsWithQuestion ? undefined : true;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsc --project tsconfig.test.json && node .test-dist/__tests__/intake.test.js"
   },
   "dependencies": {
     "next": "14.2.5",

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./.test-dist",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "lib/intake.ts",
+    "lib/__tests__/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated intake parser that detects first-time-buyer affirmations and negations without false positives
- update the chat page to trust the server history and prevent duplicated turns after reloads
- wire up a lightweight TypeScript test harness covering positive, negative, and neutral first-time-buyer messages

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc5f381c44833295a3795b965119de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Smarter recognition of “first-time buyer” intent for more accurate intake.
  - Chat now replaces the conversation with full history when available; otherwise appends a single reply.

- Tests
  - Added automated tests covering first-time buyer intent detection.

- Chores
  - Added test build configuration and scripts.
  - Updated ignore rules to exclude test build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->